### PR TITLE
Fixtiminggeorgios20102022

### DIFF
--- a/lib/POFR.pm
+++ b/lib/POFR.pm
@@ -54,7 +54,8 @@ sub getdbauth {
 
 } #end of getdbauth()
 
-sub timestamp {
+#Subroutine dbtimestamp: Gets a timesource from the database
+sub dbtimestamp {
         #get the db authentication info
         my @authinfo=getdbauth();
         my ($username,$dbname,$dbpass,$hostname);
@@ -73,7 +74,32 @@ sub timestamp {
         my ($year,$month,$day,$hour,$min,$sec)=split("-",$timearray[0]);
         $tsSQLh->finish();
         return ($year,$month,$day,$hour,$min,$sec);
-} #end of timestamp subroutine
+} #end of dbtimestamp subroutine
+
+#Subroutine timestamp: Gets a date and time from the POFR tarball to reflect the time zone of the client
+sub timestamp {
+        my $epoch=shift;
+        my $time_zone=shift;
+
+        #The epoch value we get is epoch plus msec. The msec value needs to come off.
+        my $epochminusmsec=substr $epoch,0,10;
+
+        my $dt=DateTime->from_epoch( epoch => $epochminusmsec );
+        #Here we set the time zone acquired from the POFR client
+        #to ensure that we report the time/hour on the server properly.
+        $dt->set_time_zone( $time_zone );
+
+        my $calcyear=$dt->year;
+        my $calcmonth=$dt->month;
+        my $day_of_month=$dt->day;
+        my $calchour=$dt->hour;
+        my $calcmin=$dt->minute;
+        my $calcsec=$dt->second;
+
+        return ($calcyear,$calcmonth,$day_of_month,$calchour,$calcmin,$calcsec);
+
+} #end of timestamp
+
 
 sub table_exists {
     my $db = shift;

--- a/lib/POFR.pm
+++ b/lib/POFR.pm
@@ -33,7 +33,7 @@ use Exporter;
 our @ISA= qw( Exporter );
 
 #Control what we export by default
-our @EXPORT = qw( getdbauth timestamp table_exists find_data_time_range check_requested_data_time_range date_is_later_than date_is_earlier_than get_requested_data_from_time_range determinepreviousthread sanitize_filename );
+our @EXPORT = qw( getdbauth dbtimestamp timestamp table_exists find_data_time_range check_requested_data_time_range date_is_later_than date_is_earlier_than get_requested_data_from_time_range determinepreviousthread sanitize_filename );
 
 
 #Subroutine definitions here

--- a/server/mergetables.pl
+++ b/server/mergetables.pl
@@ -424,14 +424,14 @@ sub archivetables {
         my ($lyear,$lmonth,$lday,$lhour,$lmin,$lsec,$lmsec);
 
 	#Get the first (pdata) and the last dates and times of the merged psinfodata
-	$SQLh=$hostservh->prepare("SELECT cyear,cmonth,cday,chour,cmin,csec,cmsec from psinfo ORDER BY chour,cmin,csec,cmsec LIMIT 1" );
+	$SQLh=$hostservh->prepare("SELECT cyear,cmonth,cday,chour,cmin,csec,cmsec from psinfo ORDER BY cyear,cmonth,cday,chour,cmin,csec,cmsec LIMIT 1" );
         $SQLh->execute();
         my @pdata=$SQLh->fetchrow_array();
 
 	#Listifying the @pdata array
 	($pyear,$pmonth,$pday,$phour,$pmin,$psec,$pmsec)=@pdata[0..$#pdata];
 
-	$SQLh=$hostservh->prepare("SELECT cyear,cmonth,cday,chour,cmin,csec,cmsec from psinfo ORDER BY chour DESC,cmin DESC,csec DESC LIMIT 1" );
+	$SQLh=$hostservh->prepare("SELECT cyear,cmonth,cday,chour,cmin,csec,cmsec from psinfo ORDER BY cyear DESC,cmonth DESC,cday DESC,chour DESC,cmin DESC,csec DESC,cmsec DESC LIMIT 1" );
 	$SQLh->execute();
         my @ldata=$SQLh->fetchrow_array();
 
@@ -474,11 +474,11 @@ sub archivetables {
 	
 	#Export the data into CSV files residing in RAM;
 	#obviously the order we SQL select the fields is important and needs to match that on of the table definition ( see @archivesql)
-	$SQLh=$hostservh->prepare("SELECT psentity,shanorm,shafull,uid,pid,ppid,command,arguments,tzone,cyear,cmonth,cday,cmin,chour,csec,cmsec,dyear,dmonth,dday,dhour,dmin,dsec,dmsec INTO OUTFILE '$pdatafile' FIELDS TERMINATED BY '###' LINES TERMINATED BY '\n' from psinfo ORDER BY chour,cmin,csec,cmsec");
+	$SQLh=$hostservh->prepare("SELECT psentity,shanorm,shafull,uid,pid,ppid,command,arguments,tzone,cyear,cmonth,cday,cmin,chour,csec,cmsec,dyear,dmonth,dday,dhour,dmin,dsec,dmsec INTO OUTFILE '$pdatafile' FIELDS TERMINATED BY '###' LINES TERMINATED BY '\n' from psinfo ORDER BY cyear,cmonth,cday,chour,cmin,csec,cmsec");
 	$SQLh->execute();
-	$SQLh=$hostservh->prepare("SELECT fileaccessid,shasum,filename,uid,command,pid,ppid,tzone,cyear,cmonth,cday,cmin,chour,csec,cmsec,dyear,dmonth,dday,dhour,dsec,dmin,dmsec INTO OUTFILE '$fdatafile' CHARACTER SET utf8mb4 FIELDS TERMINATED BY '###' LINES TERMINATED BY '\n' from fileinfo ORDER BY chour,cmin,csec,cmsec");
+	$SQLh=$hostservh->prepare("SELECT fileaccessid,shasum,filename,uid,command,pid,ppid,tzone,cyear,cmonth,cday,cmin,chour,csec,cmsec,dyear,dmonth,dday,dhour,dsec,dmin,dmsec INTO OUTFILE '$fdatafile' CHARACTER SET utf8mb4 FIELDS TERMINATED BY '###' LINES TERMINATED BY '\n' from fileinfo ORDER BY cyear,cmonth,cday,chour,cmin,csec,cmsec");
 	$SQLh->execute();
-	$SQLh=$hostservh->prepare("SELECT endpointinfo,cyear,cmonth,cday,chour,cmin,csec,cmsec,tzone,transport,sourceip,sourcefqdn,sourceport,destip,destfqdn,destport,ipversion,pid,uid,inode,dyear,dmonth,dday,dhour,dmin,dsec,dmsec,shasum,country,city INTO OUTFILE '$netdatafile' FIELDS TERMINATED BY '###' LINES TERMINATED BY '\n' from netinfo ORDER BY chour,cmin,csec,cmsec");
+	$SQLh=$hostservh->prepare("SELECT endpointinfo,cyear,cmonth,cday,chour,cmin,csec,cmsec,tzone,transport,sourceip,sourcefqdn,sourceport,destip,destfqdn,destport,ipversion,pid,uid,inode,dyear,dmonth,dday,dhour,dmin,dsec,dmsec,shasum,country,city INTO OUTFILE '$netdatafile' FIELDS TERMINATED BY '###' LINES TERMINATED BY '\n' from netinfo ORDER BY cyear,cmonth,cday,chour,cmin,csec,cmsec");
 	$SQLh->execute();
 
 	print "mergetables.pl STATUS: Inside the archivetables subroutine: User $usertomerge: Exported the data into CSV files residing in RAM \n";

--- a/server/pofrsreg.pl
+++ b/server/pofrsreg.pl
@@ -137,7 +137,7 @@ foreach my $req (@requests) {
 			#The dbname will be the cid without the dashes
                         $dbname =~ s/-//g;
 
-			my ($ryear,$rmonth,$rday,$rhour,$rmin,$rsec)=timestamp();
+			my ($ryear,$rmonth,$rday,$rhour,$rmin,$rsec)=dbtimestamp();
 			
 			#Quote the client hostname in case there are special characters
 			$clienthostname=$lhltservh->quote($clienthostname);


### PR DESCRIPTION
Fix timing issues by:
1. Re-introducing into the code subroutine timestamp() which times the data from the POFR tarball epoch and tz data.
2.  Dfferentiating between the timestamp() and dbtimestamp(). The latter just takes a timestamp from the RDBMS, for example to time a registration  
3. Re-ordering the data into  "ORDER BY" SQL statements to avoid a bug where the psinfo/fileinfo/netinfo tables contain data that spans multiple days (say two consecutive days), so the "ORDER BY chour,cmin,csec,cmsec" will  place the data of the latter day first. Consequently, these SQL ORDER BY statements should instead read "ORDER BY cyear,cmonth,cday,chour,cmin,csec,cmsec" and "ORDER BY cyear DESC,cmonth DESC,cday DESC,chour DESC,cmin DESC,csec DESC,cmsec DESC" to find the latest data instead.  